### PR TITLE
feat: 调色板默认隐藏仅保留🎨按钮 + 表情竖直偏移范围调整

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -328,7 +328,7 @@ window.__ModuleLoader__.load({
 			"/* === DENIA PALETTE PANEL — user customization === */",
 			"body[data-dsh-denia] [data-skin-chrome='palette-panel']{position:fixed;bottom:12px;right:12px;width:280px;max-height:70vh;overflow-y:auto;background:rgba(248,240,245,0.95);border:1px solid rgba(155,107,216,0.25);border-radius:12px;box-shadow:0 8px 32px rgba(45,27,78,0.15);z-index:10000;font-size:13px;color:#5D3A8E;-webkit-backdrop-filter:blur(8px);transition:transform 0.3s ease,opacity 0.3s ease}",
 			"body[data-dsh-denia][data-ds-dark-theme] [data-skin-chrome='palette-panel']{background:rgba(26,15,46,0.95);border-color:rgba(180,154,232,0.25);color:#F5D5E8;box-shadow:0 8px 32px rgba(0,0,0,0.3)}",
-			"body[data-dsh-denia] [data-skin-chrome='palette-panel'][data-palette-collapsed='true']{transform:translateY(calc(100% - 40px))}",
+			"body[data-dsh-denia] [data-skin-chrome='palette-panel'][data-palette-collapsed='true']{transform:translateY(calc(100% + 12px))}",
 			"body[data-dsh-denia] [data-skin-chrome='palette-panel'] *{box-sizing:border-box}",
 			"body[data-dsh-denia] [data-skin-chrome='palette-panel'] .pp-header{display:flex;align-items:center;justify-content:space-between;padding:8px 12px;cursor:pointer;font-weight:600;border-bottom:1px solid rgba(155,107,216,0.15)}",
 			"body[data-dsh-denia] [data-skin-chrome='palette-panel'] .pp-body{padding:8px 12px 12px}",

--- a/lib/client.js
+++ b/lib/client.js
@@ -1350,7 +1350,7 @@ window.__ModuleLoader__.load({
 				g3.append(makeSlider("立绘高度", "charHeight", 30, 80, 1, "vh"));
 				g3.append(makeSlider("立绘水平偏移", "charOffsetX", -50, 50, 1, "px"));
 				g3.append(makeSlider("表情大小", "chibiSize", 60, 240, 10, "px"));
-				g3.append(makeSlider("表情竖直偏移", "chibiOffsetY", -200, 200, 10, "px"));
+				g3.append(makeSlider("表情竖直偏移", "chibiOffsetY", -420, 300, 10, "px"));
 				g3.append(makeSlider("背景透明度", "bgOpacity", 20, 100, 1, "%"));
 				g3.append(makeToggle("消息文本框", "msgFrame"));
 				g3.append(makeSlider("文本框透明度", "msgOpacity", 20, 100, 1, "%"));


### PR DESCRIPTION
## 改动内容

两个小改动（2 个 commit，均在 `lib/client.js`）：

### 1. 调色板面板默认完全隐藏，仅保留 🎨 圆形开关按钮
- 折叠 CSS 由 `translateY(calc(100% - 40px))`（折叠时露出 40px 头部条，常驻可见）改为 `translateY(calc(100% + 12px))`（完全滑出屏幕）
- 初始只显示右下角圆形 🎨 按钮；点击弹出调色板，再点（或点面板头部）隐藏
- 面板默认 `data-palette-collapsed="true"` 的既有逻辑不变，动画保留

### 2. 表情竖直偏移范围调整为 -420~300px
- 原范围 `-200~200px`：吉祥物基准在 `58vh`（rail）/ `48vh`，向上可移动约 42vh，向下空间不足，常见视口下 **-200px 到不了底部**
- 新范围 `-420~300px`：向上 +300 可到顶端，向下 -420 可贴视口底部（按 ~700-830px 视口实测），滑块无死区

## 验证方式
- 浏览器实测：刷新后调色板面板不再常驻，🎨 按钮点击弹出/隐藏正常
- CDP 实测（1440×900 视口）：offset=+300 → 吉祥物 top=24（贴顶）；offset=-420 → 贴底
- 服务器实时读取 client.js（`cache-control: no-cache`），无需重启 DSH

## 兼容性
- 默认值 0 不变；localStorage 旧设置值（-200~200 范围内）均有效
- "恢复默认设置"重建面板后仍为默认隐藏状态