### PR TITLE
feat: add message text color recolor toggle to palette (Denia palette)

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -358,7 +358,34 @@ window.__ModuleLoader__.load({
 			"body[data-dsh-denia][data-denia-msg-frame='on'] [data-denia-msg]{transition:none!important}",
 			/* Void erosion (dark mode msg glow) */
 			"body[data-dsh-denia][data-denia-msg-frame='on'][data-ds-dark-theme] [data-denia-msg]{position:relative}",
-			"body[data-dsh-denia][data-denia-msg-frame='on'][data-ds-dark-theme] [data-denia-msg]::before{content:'';position:absolute;inset:0;border-radius:inherit;background:radial-gradient(ellipse 70% 50% at 10% 40%,rgba(155,107,216,0.18) 0%,transparent 60%),radial-gradient(ellipse 60% 40% at 90% 20%,rgba(180,154,232,0.15) 0%,transparent 55%),radial-gradient(ellipse 50% 60% at 50% 90%,rgba(123,77,190,0.12) 0%,transparent 50%);pointer-events:none;z-index:-1;filter:blur(6px)}"
+			"body[data-dsh-denia][data-denia-msg-frame='on'][data-ds-dark-theme] [data-denia-msg]::before{content:'';position:absolute;inset:0;border-radius:inherit;background:radial-gradient(ellipse 70% 50% at 10% 40%,rgba(155,107,216,0.18) 0%,transparent 60%),radial-gradient(ellipse 60% 40% at 90% 20%,rgba(180,154,232,0.15) 0%,transparent 55%),radial-gradient(ellipse 50% 60% at 50% 90%,rgba(123,77,190,0.12) 0%,transparent 50%);pointer-events:none;z-index:-1;filter:blur(6px)}",
+			/* === MESSAGE TEXT COLOR — aemeath-style recolor, Denia palette (toggleable) === */,
+			"body[data-dsh-denia][data-denia-msg-color='on'] [data-denia-msg]{color:#5D3A8E}",
+			"body[data-dsh-denia][data-denia-msg-color='on'] [data-denia-msg] p{color:#5D3A8E}",
+			"body[data-dsh-denia][data-denia-msg-color='on'] [data-denia-msg] h1,body[data-dsh-denia][data-denia-msg-color='on'] [data-denia-msg] h2,body[data-dsh-denia][data-denia-msg-color='on'] [data-denia-msg] h3{background:linear-gradient(120deg,#E8A5BF,#9B6BD8 45%,#7FA8D8);-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent;color:transparent}",
+			"body[data-dsh-denia][data-denia-msg-color='on'] [data-denia-msg] a{color:#9B6BD8;text-decoration-color:rgba(155,107,216,0.4)}",
+			"body[data-dsh-denia][data-denia-msg-color='on'] [data-denia-msg] a:hover{color:#7A4FC0}",
+			"body[data-dsh-denia][data-denia-msg-color='on'] [data-denia-msg] strong,body[data-dsh-denia][data-denia-msg-color='on'] [data-denia-msg] em,body[data-dsh-denia][data-denia-msg-color='on'] [data-denia-msg] b{color:#C05A7E}",
+			"body[data-dsh-denia][data-denia-msg-color='on'] [data-denia-msg] code{color:#4A7BB8;background:rgba(160,196,232,0.16)}",
+			"body[data-dsh-denia][data-denia-msg-color='on'] [data-denia-msg] pre{background:rgba(160,196,232,0.10);border:1px solid rgba(160,196,232,0.22);border-left:3px solid #C5A468}",
+			"body[data-dsh-denia][data-denia-msg-color='on'] [data-denia-msg] pre code{color:#3E68A0;background:transparent}",
+			"body[data-dsh-denia][data-denia-msg-color='on'] [data-denia-msg] blockquote{color:#766A92;background:rgba(232,165,191,0.08);border-left:3px solid #E8A5BF}",
+			"body[data-dsh-denia][data-denia-msg-color='on'] [data-denia-msg] ul,body[data-dsh-denia][data-denia-msg-color='on'] [data-denia-msg] ol{color:#5D3A8E}",
+			"body[data-dsh-denia][data-denia-msg-color='on'] [data-denia-msg] li::marker{color:#9B6BD8}",
+			"body[data-dsh-denia][data-denia-msg-color='on'] [data-denia-msg] hr{border-color:rgba(155,107,216,0.25)}",
+			"body[data-dsh-denia][data-denia-msg-color='on'][data-ds-dark-theme] [data-denia-msg]{color:#E6C8F2}",
+			"body[data-dsh-denia][data-denia-msg-color='on'][data-ds-dark-theme] [data-denia-msg] p{color:#E6C8F2}",
+			"body[data-dsh-denia][data-denia-msg-color='on'][data-ds-dark-theme] [data-denia-msg] h1,body[data-dsh-denia][data-denia-msg-color='on'][data-ds-dark-theme] [data-denia-msg] h2,body[data-dsh-denia][data-denia-msg-color='on'][data-ds-dark-theme] [data-denia-msg] h3{background:linear-gradient(120deg,#F0A8C8,#B08AE8 45%,#8FD3E8);-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent;color:transparent}",
+			"body[data-dsh-denia][data-denia-msg-color='on'][data-ds-dark-theme] [data-denia-msg] a{color:#B0A4F0;text-decoration-color:rgba(176,164,240,0.4)}",
+			"body[data-dsh-denia][data-denia-msg-color='on'][data-ds-dark-theme] [data-denia-msg] a:hover{color:#C8B8FF}",
+			"body[data-dsh-denia][data-denia-msg-color='on'][data-ds-dark-theme] [data-denia-msg] strong,body[data-dsh-denia][data-denia-msg-color='on'][data-ds-dark-theme] [data-denia-msg] em,body[data-dsh-denia][data-denia-msg-color='on'][data-ds-dark-theme] [data-denia-msg] b{color:#F0A8C8}",
+			"body[data-dsh-denia][data-denia-msg-color='on'][data-ds-dark-theme] [data-denia-msg] code{color:#A0C4E8;background:rgba(160,196,232,0.14)}",
+			"body[data-dsh-denia][data-denia-msg-color='on'][data-ds-dark-theme] [data-denia-msg] pre{background:rgba(160,196,232,0.08);border:1px solid rgba(160,196,232,0.2);border-left:3px solid #C5A468}",
+			"body[data-dsh-denia][data-denia-msg-color='on'][data-ds-dark-theme] [data-denia-msg] pre code{color:#B8D8F0;background:transparent}",
+			"body[data-dsh-denia][data-denia-msg-color='on'][data-ds-dark-theme] [data-denia-msg] blockquote{color:#CCD8EC;background:rgba(232,165,191,0.06);border-left:3px solid #E8A5BF}",
+			"body[data-dsh-denia][data-denia-msg-color='on'][data-ds-dark-theme] [data-denia-msg] ul,body[data-dsh-denia][data-denia-msg-color='on'][data-ds-dark-theme] [data-denia-msg] ol{color:#E2CCEC}",
+			"body[data-dsh-denia][data-denia-msg-color='on'][data-ds-dark-theme] [data-denia-msg] li::marker{color:#E8A5BF}",
+			"body[data-dsh-denia][data-denia-msg-color='on'][data-ds-dark-theme] [data-denia-msg] hr{border-color:rgba(180,154,232,0.3)}"
 		].join("\n");
 
 		var tagId = "@dsh-external/dsh-client-ui-skin-denia/denia.module.css";
@@ -1073,7 +1100,7 @@ window.__ModuleLoader__.load({
 				darkLeftChar: true, darkRightChar: true, darkChibi: true,
 				contentWidth: 780, charHeight: 55, charOffsetX: 0,
 				chibiSize: 120, chibiOffsetY: 0,
-				bgOpacity: 100, msgFrame: false, msgOpacity: 68,
+				bgOpacity: 100, msgFrame: false, msgColor: false, msgOpacity: 68,
 				bubbles: true, bubbleCount: 20, bubbleSpeed: 100,
 				chainBorder: true, trim: true
 			};
@@ -1138,6 +1165,18 @@ window.__ModuleLoader__.load({
 					});
 				}
 				body.style.setProperty("--denia-msg-opacity", paletteSettings.msgOpacity / 100);
+				// Message text color (aemeath-style recolor, Denia palette)
+				if (paletteSettings.msgColor) {
+					body.setAttribute("data-denia-msg-color", "on");
+					// Ensure message tags exist even when msg frame is off
+					if (!msgFrameActive && msgFrameObserver) {
+						msgFrameObserver.observe(document.body, { childList: true, subtree: true });
+						msgFrameActive = true;
+					}
+					if (typeof decorateMessageFrames === "function") decorateMessageFrames();
+				} else {
+					body.removeAttribute("data-denia-msg-color");
+				}
 				// Toggle effects
 				var bubbleFg = body.querySelector("[data-skin-chrome='bubble-field']");
 				var bubbleBg = body.querySelector("[data-skin-chrome='bubble-field-bg']");
@@ -1353,6 +1392,7 @@ window.__ModuleLoader__.load({
 				g3.append(makeSlider("表情竖直偏移", "chibiOffsetY", -200, 200, 10, "px"));
 				g3.append(makeSlider("背景透明度", "bgOpacity", 20, 100, 1, "%"));
 				g3.append(makeToggle("消息文本框", "msgFrame"));
+				g3.append(makeToggle("消息文字配色", "msgColor"));
 				g3.append(makeSlider("文本框透明度", "msgOpacity", 20, 100, 1, "%"));
 				g3.append(makeToggle("泡泡粒子场", "bubbles"));
 				g3.append(makeSlider("泡泡数量", "bubbleCount", 5, 40, 1, ""));


### PR DESCRIPTION
## 变更内容

为达妮娅皮肤调色板新增「消息文字配色」开关，为 AI 回复消息提供达妮娅专属配色，亮/暗双形态各一套：

- **亮色（布景之形）**：正文深紫 #5D3A8E，标题粉→紫→蓝渐变，链接紫、强调玫红、代码蓝、引用粉边框
- **暗色（幻灭之形）**：正文 #E6C8F2，标题粉→紫→青蓝渐变，链接淡紫、强调粉、代码青蓝

## 改动点

- 调色板新增「消息文字配色」开关（独立于「消息文本框」，开启时自动标记消息元素，关闭即清理）
- paletteDefaults 新增 msgColor 默认值
- 新增 27 条 CSS（亮暗两套）

## 变更文件

- lib/client.js：+42 / -2

## 说明

- 设置存 localStorage（与现有调色板设置一致）
- 已通过语法检查与模块加载验证